### PR TITLE
update aports clone URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ builder:
 target:
 	mkdir -p target
 aports:
-	git clone git://dev.alpinelinux.org/aports
+	git clone https://git.alpinelinux.org/aports
 
 .PHONY: aports_update
 aports_update: aports


### PR DESCRIPTION
dev.alpinelinux.org/aports is no longer valid.